### PR TITLE
(WIP) Add fix for iOS layout shadow wrapper

### DIFF
--- a/lib/src/nativescript-ngx-shadow/ng-shadow.directive.ts
+++ b/lib/src/nativescript-ngx-shadow/ng-shadow.directive.ts
@@ -18,6 +18,8 @@ import { Shadow } from './common/shadow';
 import { Shape, ShapeEnum } from './common/shape.enum';
 import { View } from 'tns-core-modules/ui/page/page';
 import { StackLayout } from 'tns-core-modules/ui/layouts/stack-layout';
+import {GridLayout} from "tns-core-modules/ui/layouts/grid-layout";
+
 import { addWeakEventListener, removeWeakEventListener } from "tns-core-modules/ui/core/weak-event-listener";
 declare const android: any;
 
@@ -131,8 +133,19 @@ export class NativeShadowDirective implements OnInit, OnChanges, AfterViewInit, 
         'StackLayout'
       ) as StackLayout;
 
+
+
+
       // wrappingElement.cssClasses = mainElement.cssClasses;
       const parent = originalElement.parentNode;
+
+      // Account for GridLayout properties
+      if (parent instanceof GridLayout) {
+        const gridProperties = ["row", "col", "rowSpan", "colSpan"];
+        for (let property of gridProperties) {
+          this.iosShadowRapper[property] = originalElement[property];
+        }
+      }
       this.render.insertBefore(parent, this.iosShadowRapper, originalElement);
       this.render.removeChild(parent, originalElement);
       this.render.appendChild(this.iosShadowRapper, originalElement);


### PR DESCRIPTION
For layouts which use the position of the child element in the layout structure as the element's position (StackLayout, for example), the plugin works fine. However, for layouts where child node position may not have any correlation to the element's rendered UI (GridLayout, AbsoluteLayout, etc.), you end up running into problems.

For example, take the following layout on iOS:
```xml
<GridLayout rows="auto auto auto">
  <Label text="0" row="0"></Label>
  <Label text="1" row="1" shadow="10"></Label>
  <Label text="2" row="2"></Label>
</GridLayout>
```

Under the hood, this happens:
```xml
<GridLayout rows="auto auto auto">
  <Label text="0" row="0"></Label>
  <StackLayout>
    <Label text="1" row="1" shadow="10"></Label>
  </StackLayout>
  <Label text="2" row="2"></Label>
</GridLayout>
```

So the second label does not render correctly.

Currently this PR just applies the row, column, rowSpan, and colSpan attributes to the wrapping StackLayout if the original element is wrapped in a GridLayout.

More work needs to be done so that the wrapping StackLayout gets the correct attributes from the original element in order to render in the view correctly for all layouts - I believe #17 was caused by a similar issue for AbsoluteLayouts.

As-is, this is mergeable but does not account for all possible use cases.